### PR TITLE
deprecate check_schema_status replaced by raft

### DIFF
--- a/importer/schema_corruption_checker.py
+++ b/importer/schema_corruption_checker.py
@@ -9,28 +9,6 @@ host = os.getenv("HOST")
 tenants_goal = int(os.getenv("TENANTS_GOAL"))
 client = weaviate.Client(f"http://{host}", timeout_config=(20, 240))
 
-failure_threshold = 5
-failures = 0
-
-
-def check_schema_status(client: weaviate.Client):
-    global failures
-    res = requests.get(f"http://{host}/v1/schema/cluster-status")
-    if res.status_code != 200:
-        parsed = res.json()
-        if "concurrent transaction" in parsed["error"]:
-            logger.info("concurrent transaction, try again next time")
-            return
-        if failures < failure_threshold:
-            logger.warning(res.json())
-            failures += 1
-        else:
-            logger.error(res.json())
-            sys.exit(1)
-    else:
-        failures = 0
-        logger.info(res.json())
-
 
 def check_progess(client: weaviate.Client):
     res = requests.get(f"http://{host}/v1/nodes?output=verbose")
@@ -49,8 +27,4 @@ i = 0
 while True:
     if i % 10 == 0:
         check_progess(client)
-
-    time.sleep(3)
-    check_schema_status(client)
-
     i += 1


### PR DESCRIPTION
`v1/schema/cluster-status` endpoint got deprecated in [PR](https://github.com/weaviate/weaviate/pull/4846) given the fact that the idea of an out of sync schema is no longer possible in RAFT
